### PR TITLE
Feature/implements filled form

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -19,7 +19,7 @@ const Input: React.FC<InputProps> = ({ name, icon: Icon, ...rest }) => {
   const InputRef = useRef<HTMLInputElement>(null);
   const [isFilled, setIsFilled] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
-  const { fieldName, error, registerField } = useField(name);
+  const { fieldName, error, registerField, defaultValue } = useField(name);
 
   const handleInputFocus = useCallback(() => {
     setIsFocused(true);
@@ -46,6 +46,7 @@ const Input: React.FC<InputProps> = ({ name, icon: Icon, ...rest }) => {
       <input
         onFocus={handleInputFocus}
         onBlur={handleInputBlur}
+        defaultValue={defaultValue}
         ref={InputRef}
         {...rest}
       />

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -13,9 +13,10 @@ import { useField } from '@unform/core';
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   name: string;
   icon?: React.ComponentType<IconBaseProps>;
+  disabled?: boolean;
 }
 
-const Input: React.FC<InputProps> = ({ name, icon: Icon, ...rest }) => {
+const Input: React.FC<InputProps> = ({ name, icon: Icon, disabled = false, ...rest }) => {
   const InputRef = useRef<HTMLInputElement>(null);
   const [isFilled, setIsFilled] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -48,6 +49,7 @@ const Input: React.FC<InputProps> = ({ name, icon: Icon, ...rest }) => {
         onBlur={handleInputBlur}
         defaultValue={defaultValue}
         ref={InputRef}
+        disabled={disabled}
         {...rest}
       />
       {error && (

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -16,7 +16,7 @@ const Select: React.FC<Props> = ({ name, options, ...rest }) => {
   const selectRef = useRef<HTMLSelectElement>(null);
   const [isFilled, setIsFilled] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
-  const { fieldName, defaultValue, registerField, error } = useField(name);
+  const { fieldName, registerField, error } = useField(name);
 
   useEffect(() => {
     registerField({

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,45 +1,71 @@
-import React, { useRef, useEffect } from 'react';
-import ReactSelect, {
+import React, { useRef, useEffect, useCallback, useState } from 'react';
+import {
   OptionTypeBase,
   Props as SelectProps,
 } from 'react-select';
 import { useField } from '@unform/core';
+import { Container, Error } from './styles';
+import { FiAlertCircle } from 'react-icons/fi';
 
 interface Props extends SelectProps<OptionTypeBase> {
   name: string;
+  options: { value: string; label: string }[];
 }
 
-const Select: React.FC<Props> = ({ name, ...rest }) => {
-  const selectRef = useRef(null);
-  const { fieldName, defaultValue, registerField } = useField(name);
+const Select: React.FC<Props> = ({ name, options, ...rest }) => {
+  const selectRef = useRef<HTMLSelectElement>(null);
+  const [isFilled, setIsFilled] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const { fieldName, defaultValue, registerField, error } = useField(name);
 
   useEffect(() => {
     registerField({
       name: fieldName,
       ref: selectRef.current,
       getValue: (ref: any) => {
-        if (rest.isMulti) {
-          if (!ref.state.value) {
-            return [];
-          }
-          return ref.state.value.map((option: OptionTypeBase) => option.value);
-        }
-        if (!ref.state.value) {
+        if (!ref.value) {
           return '';
         }
-        return ref.state.value.value;
+        return ref.value;
       },
+      setValue: (ref, value) => {
+        ref.value = value
+      }
     });
-  }, [fieldName, registerField, rest.isMulti]);
+  }, [fieldName, registerField]);
+
+  const handleInputFocus = useCallback(() => {
+    setIsFocused(true);
+  }, []);
+
+  const handleInputBlur = useCallback(() => {
+    setIsFocused(false);
+    setIsFilled(!!selectRef.current?.value);
+  }, []);
 
   return (
-    <ReactSelect
-      defaultValue={defaultValue}
-      ref={selectRef}
-      classNamePrefix="react-select"
-      {...rest}
-    />
-  );
+    <>
+      <Container isErrored={!!error} isFocused={isFocused} isFilled={isFilled}>
+        <select
+          ref={selectRef}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          style={{ width: '100%', padding: '10px' }}
+          name={name}
+        >
+          <option disabled selected></option>
+          {options?.map(o => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+        {error && (
+        <Error title={error}>
+          <FiAlertCircle color="#c53030" size={20} />
+        </Error>
+      )}
+      </Container>
+    </>
+  )
 };
 
 export default Select;

--- a/src/components/Select/styles.ts
+++ b/src/components/Select/styles.ts
@@ -1,0 +1,64 @@
+import styled, { css } from 'styled-components';
+import { lighten } from 'polished';
+import Tooltip from '../Tooltip';
+
+interface ContainerProps {
+  isFocused: boolean;
+  isFilled: boolean;
+  isErrored: boolean;
+}
+
+export const Container = styled.div<ContainerProps>`
+  background: #fff;
+  border-radius: 10px;
+  border: 1px solid #fff;
+  padding: 6px;
+  width: 100%;
+  transition: 0.5s;
+  display: flex;
+  align-items: center;
+  & + div {
+    margin-top: 8px;
+  }
+  ${(props) =>
+    props.isFocused
+      ? css`
+          border: 1px solid #59748c;
+        `
+      : ''}
+  select {
+    color: #59748c;
+    flex: 1;
+    background: transparent;
+    border: 0;
+    transition: 0.3s;
+
+    &::placeholder {
+      color: '#666360';
+    }
+    &:focus {
+      border-bottom: 1px solid ${lighten(0.3, '#59748c')};
+      padding-bottom: 5px;
+    }
+  }
+  svg {
+    margin-right: 16px;
+  }
+`;
+
+export const Error = styled(Tooltip)`
+  height: 20px;
+  margin-left: 16px;
+
+  svg {
+    margin: 0;
+  }
+
+  span {
+    background: #c53030;
+    color: #fff;
+    &::before {
+      border-color: #c53030 transparent;
+    }
+  }
+`;

--- a/src/components/interviewBadge/index.tsx
+++ b/src/components/interviewBadge/index.tsx
@@ -3,6 +3,7 @@ import { parseJSON, format } from 'date-fns';
 import {
   Container
 } from './styles';
+import { useHistory } from 'react-router-dom';
 
 interface InterviewProps {
   interview: {
@@ -25,9 +26,10 @@ const Card: React.FC<InterviewProps> = ({ interview: { project_name,
   id,
   comments,
   created_at } }) => {
+    const history = useHistory()
 
   return (
-    <Container>
+    <Container onClick={() => history.push(`/interview/${id}`)}>
       <div><strong>Nome do projeto:</strong> {project_name}</div>
       <div><strong>Id da entrevista:</strong> {id?.split('').splice(1, 6).join('')}</div>
       <div><strong>Comentários:</strong> {comments}</div>

--- a/src/components/interviewBadge/styles.ts
+++ b/src/components/interviewBadge/styles.ts
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   display: grid;
+  cursor: pointer;
   color: #59748c;
   gap: 0.3rem;
   padding: 1rem;

--- a/src/pages/Interview/Forms/AddressForm/index.tsx
+++ b/src/pages/Interview/Forms/AddressForm/index.tsx
@@ -31,9 +31,11 @@ import api from '../../../../services/api';
 interface AddressFormProps {
   dispatch: Function;
   offline: boolean;
+  isEditForm?: boolean;
+  initialValues?: any;
 }
 
-const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline }) => {
+const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline, isEditForm = false, initialValues = {} }) => {
 
   const { addToast } = useToast();
 
@@ -83,8 +85,6 @@ const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline }) => {
 
         const offlineInterviews: { [key: string]: ICreateOfflineInterviewDTO } = JSON.parse(localStorage.getItem('@Safety:offline-interviews') || '{}');
 
-        console.log('interviews', offlineInterviews);
-
         const addAddress = offlineInterviews.hasOwnProperty(uniqueId) ? { ...offlineInterviews, [uniqueId]: { ...offlineInterviews[uniqueId], address } } : false;
 
         if (addAddress) {
@@ -116,6 +116,18 @@ const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline }) => {
     }
   }, [addToast, token, dispatch, offline]);
 
+  if (isEditForm) {
+    AddressFormRef.current?.setData({
+      post_code: initialValues?.post_code,
+      state: initialValues?.state,
+      city: initialValues?.city,
+      neighborhood: initialValues?.neighborhood,
+      street_or_location: initialValues?.street_or_location,
+      house_number: initialValues?.house_number,
+      telephone_number: initialValues?.telephone_number,
+    })
+  }
+
   return (
     <StyledForm ref={AddressFormRef} onSubmit={handleAddressSubmit}>
       <section>
@@ -144,7 +156,7 @@ const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline }) => {
           placeholder="Número de telefone"
           name="telephone_number"
         />
-        <Button>Submit</Button>
+        {!isEditForm && <Button>Submit</Button>}
       </section>
     </StyledForm>
 

--- a/src/pages/Interview/Forms/AddressForm/index.tsx
+++ b/src/pages/Interview/Forms/AddressForm/index.tsx
@@ -121,7 +121,7 @@ const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline }) => {
       <section>
         <Input name="post_code" placeholder="Código Postal" icon={FiMail} />
         <Label>Estado da Federação</Label>
-        <Select name="state" options={brazilStatesOptions} id="state" />
+        <Select name="state" options={brazilStatesOptions} />
       </section>
       <section>
         <Input name="city" placeholder="Cidade" icon={FiMap} />

--- a/src/pages/Interview/Forms/HouseholdForm/index.tsx
+++ b/src/pages/Interview/Forms/HouseholdForm/index.tsx
@@ -196,7 +196,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         < Select
           name="povos_tradicionais"
           options={yesOrNoOptions}
-          onChange={selectedOption => setTraditional(selectedOption)}
+          onChange={(selectedOption: any) => setTraditional(selectedOption)}
         />
         <Label>D4 - Qual comunidade tradicional ou povos?</Label>
         < Select
@@ -208,7 +208,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         < Select
           name="pessoa_de_referencia"
           options={yesOrNoOptions}
-          onChange={selectedOption => setMainPerson(selectedOption)}
+          onChange={(selectedOption: any) => setMainPerson(selectedOption)}
         />
 
         <Label>D6 - Qual a idade da pessoa de referência?</Label>
@@ -367,7 +367,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
                 type="number"
               />
               <Label>
-                D29 - Desde o início da pandemia do Coronavírus (ou Convid-19) em 2020 até o dia de hoje, vocês acolheram alguém na sua família como morador permanente? 
+                D29 - Desde o início da pandemia do Coronavírus (ou Convid-19) em 2020 até o dia de hoje, vocês acolheram alguém na sua família como morador permanente?
               </Label>
               <Select
                 name="pessoas_convidadas"
@@ -473,7 +473,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="educacao_basica_publica"
           options={yesOrNoOptions}
-          onChange={selectedOption => setEduc(selectedOption)}
+          onChange={(selectedOption: any) => setEduc(selectedOption)}
         />
 
         <Label>
@@ -548,7 +548,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="auxilio_emergencial"
           options={yesOrNoOptions}
-          onChange={selectedOption => {
+          onChange={(selectedOption: any) => {
             setAuxilio(selectedOption)
           }}
         />
@@ -568,7 +568,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="ajuda_instituicao_caridade"
           options={ajuda_instituicao_caridade}
-          onChange={selectedOption => setAjuda(selectedOption)}
+          onChange={(selectedOption: any) => setAjuda(selectedOption)}
         />
 
         <Label>
@@ -597,7 +597,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="produz_alimento"
           options={yesOrNoOptions}
-          onChange={selectedOptions => setHomegrown(selectedOptions)}
+          onChange={(selectedOptions: any) => setHomegrown(selectedOptions)}
         />
 
         <Label>D49 - Este domicílio tem água suficiente para animais (dessedentação)?</Label>
@@ -621,7 +621,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="alimento_para_venda"
           options={yesOrNoOptions}
-          onChange={selectedOptions => setProduce(selectedOptions)}
+          onChange={(selectedOptions: any) => setProduce(selectedOptions)}
           isDisabled={homegrown?.value === 'true' ? false : true}
         />
 
@@ -665,7 +665,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="preocupacao_alimentos"
           options={yesOrNoOptions}
-          onChange={selectedOption => setPreoAlimentos(selectedOption)}
+          onChange={(selectedOption: any) => setPreoAlimentos(selectedOption)}
         />
         <Label>
           D56 - NOS ÚLTIMOS TRÊS MESES, <b>OS ALIMENTOS ACABARAM</b> ANTES QUE OS MORADORES DO SEU DOMICÍLIO TIVESSEM DINHEIRO PARA COMPRAR MAIS COMIDA?
@@ -673,7 +673,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="alimentos_acabaram"
           options={yesOrNoOptions}
-          onChange={selectedOption => setAcabAlimentos(selectedOption)}
+          onChange={(selectedOption: any) => setAcabAlimentos(selectedOption)}
         />
         <Label>
           D57 - NOS ÚLTIMOS TRÊS MESES OS MORADORES DO SEU DOMICÍLIO <b>FICARAM SEM DINHEIRO PARA TER UMA ALIMENTAÇÃO SAUDÁVEL E VARIADA</b>?
@@ -681,7 +681,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="alimentos_saudaveis"
           options={yesOrNoOptions}
-          onChange={selectedOption => setSaudAlimentos(selectedOption)}
+          onChange={(selectedOption: any) => setSaudAlimentos(selectedOption)}
         />
         <Label>
           D58 - NOS ÚLTIMOS TRÊS MESES, OS MORADORES DO SEU DOMICÍLIO <b>COMERAM APENAS ALGUNS POUCOS TIPOS DE ALIMENTOS</b> QUE AINDA TINHAM PORQUE O DINHEIRO ACABOU?
@@ -737,7 +737,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         <Select
           name="alteracao_preco_comida"
           options={alteracao_preco_comida}
-          onChange={selectedOption => setBuyingProfile(selectedOption)}
+          onChange={(selectedOption: any) => setBuyingProfile(selectedOption)}
         />
 
         <Label>

--- a/src/pages/Interview/Forms/HouseholdForm/index.tsx
+++ b/src/pages/Interview/Forms/HouseholdForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import {
   OptionTypeBase
 } from 'react-select';
@@ -60,9 +60,11 @@ import ICreateOfflineInterviewDTO from '../../dtos/ICreateOfflineInterviewDTO';
 interface HouseholdFormProps {
   dispatch: Function;
   offline: boolean;
+  isEditForm?: boolean;
+  initialValues?: any;
 }
 
-const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
+const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline, isEditForm = false, initialValues = {} }) => {
 
   const { token } = useAuth();
 
@@ -183,6 +185,111 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
     [addToast, token, dispatch, offline],
   );
 
+  if (isEditForm) {
+    HouseholdFormRef.current?.setData({
+      local_do_domicilio: initialValues?.local_do_domicilio,
+      morador_de_rua: initialValues?.morador_de_rua,
+      povos_tradicionais: initialValues?.povos_tradicionais,
+      qual_povo_tradicional: initialValues?.qual_povo_tradicional,
+      pessoa_de_referencia: initialValues?.pessoa_de_referencia,
+      idade_pessoa_de_referencia: initialValues?.idade_pessoa_de_referencia,
+      sexo_pessoa_de_referencia: initialValues?.sexo_pessoa_de_referencia,
+      raca_cor: initialValues?.raca_cor,
+      nao_sabe_renda: initialValues?.nao_sabe_renda ? 'nao_sabe_renda' : '',
+      ler_escrever: initialValues?.ler_escrever,
+      escolaridade: initialValues?.escolaridade,
+      situacao_de_trabalho: initialValues?.situacao_de_trabalho,
+      covid_perda: initialValues?.covid_perda,
+      tipo_de_residencia: initialValues?.tipo_de_residencia,
+      numero_de_comodos: initialValues?.numero_de_comodos,
+      material_de_construcao: initialValues?.material_de_construcao,
+      agua_potavel: initialValues?.agua_potavel,
+      esgoto: initialValues?.esgoto,
+      numero_de_pessoas: initialValues?.numero_de_pessoas,
+      uma_pessoa_domicilio: initialValues?.uma_pessoa_domicilio ? 'uma_pessoa_domicilio' : '',
+      cinco_anos_ou_mais: initialValues?.cinco_anos_ou_mais,
+      entre_6_e_18: initialValues?.entre_6_e_18,
+      entre_19_e_59: initialValues?.entre_19_e_59,
+      sessenta_anos_ou_mais: initialValues?.sessenta_anos_ou_mais,
+      pessoas_convidadas: initialValues?.pessoas_convidadas,
+      renda_familiar: initialValues?.renda_familiar,
+      faixa_de_renda: initialValues?.faixa_de_renda,
+      educacao_basica_publica: initialValues?.educacao_basica_publica,
+      pnae: initialValues?.pnae,
+      cadastro_unico: initialValues?.cadastro_unico,
+      bolsa_familia: initialValues?.bolsa_familia,
+      bpc: initialValues?.bpc,
+      pensao: initialValues?.pensao,
+      auxilio_reclusao: initialValues?.auxilio_reclusao,
+      cesta_de_alimentos: initialValues?.cesta_de_alimentos,
+      restaurantes_populares: initialValues?.restaurantes_populares,
+      auxilio_emergencial: initialValues?.auxilio_emergencial,
+      auxilio_vezes: initialValues?.auxilio_vezes,
+      ajuda_instituicao_caridade: initialValues?.ajuda_instituicao_caridade,
+      tipo_de_ajuda: initialValues?.tipo_de_ajuda,
+      vergonha: initialValues?.vergonha,
+      produz_alimento: initialValues?.produz_alimento,
+      agua_animais: initialValues?.agua_animais,
+      agua_producao_alimentos: initialValues?.agua_producao_alimentos,
+      alimento_para_venda: initialValues?.alimento_para_venda,
+      divisao_alimento: initialValues?.divisao_alimento,
+      dificuldade_venda: initialValues?.dificuldade_venda,
+      nao_vendeu: initialValues?.nao_vendeu,
+      preocupacao_alimentos: initialValues?.preocupacao_alimentos,
+      alimentos_acabaram: initialValues?.alimentos_acabaram,
+      alimentos_saudaveis: initialValues?.alimentos_saudaveis,
+      alimentos_poucos_tipos: initialValues?.alimentos_poucos_tipos,
+      refeicoes_adulto: initialValues?.refeicoes_adulto,
+
+
+      ocupacao_profissional: initialValues?.ocupacao_profissional,
+      local_de_trabalho: initialValues?.local_de_trabalho,
+      covid_2020: initialValues?.covid_2020,
+      covid_2021: initialValues?.covid_2021,
+      covid_2022: initialValues?.covid_2022,
+
+      adulto_comeu_menos: initialValues?.adulto_comeu_menos,
+      adulto_fome: initialValues?.adulto_fome,
+      adulto_uma_refeicao: initialValues?.adulto_uma_refeicao,
+      como_adquiriu_comida: initialValues?.como_adquiriu_comida,
+      alteracao_preco_comida: initialValues?.alteracao_preco_comida,
+      perfil_de_compra: initialValues?.perfil_de_compra,
+      mercado: initialValues?.mercado,
+      gastos_alimentacao: initialValues?.gastos_alimentacao,
+
+      perda_de_emprego: initialValues?.perda_de_emprego ? 'perda_de_emprego' : '',
+      reducao_de_salario: initialValues?.reducao_de_salario ? 'reducao_de_salario' : '',
+      ajuda_financeira: initialValues?.ajuda_financeira ? 'ajuda_financeira' : '',
+      divida: initialValues?.divida ? 'divida' : '',
+      corte_de_gastos: initialValues?.corte_de_gastos ? 'corte_de_gastos' : '',
+      corte_de_gastos_nao_essenciais: initialValues?.corte_de_gastos_nao_essenciais ? 'corte_de_gastos_nao_essenciais' : '',
+      ns_nr_trabalho: initialValues?.ns_nr_trabalho ? 'ns_nr_trabalho' : '',
+
+      feijao: initialValues?.feijao ? 'feijao' : '',
+      arroz: initialValues?.arroz ? 'arroz' : '',
+      carnes: initialValues?.carnes ? 'carnes' : '',
+      verduras_legumes: initialValues?.verduras_legumes ? 'verduras_legumes' : '',
+      frutas_frescas: initialValues?.frutas_frescas ? 'frutas_frescas' : '',
+      leite: initialValues?.leite ? 'leite' : '',
+      hamburguer_embutidos: initialValues?.hamburguer_embutidos ? 'hamburguer_embutidos' : '',
+      bebidas_adocadas: initialValues?.bebidas_adocadas ? 'bebidas_adocadas' : '',
+      macarrao_instantaneo_salgadinhos_de_pacote_biscoitos_salgados: initialValues?.macarrao_instantaneo_salgadinhos_de_pacote_biscoitos_salgados ? 'macarrao_instantaneo_salgadinhos_de_pacote_biscoitos_salgados' : '',
+      biscoito_recheado_doces_guloseimas: initialValues?.biscoito_recheado_doces_guloseimas ? 'biscoito_recheado_doces_guloseimas' : ''
+    })
+  }
+
+  useEffect(() => {
+    if (initialValues?.pessoa_de_referencia) {
+      if (initialValues?.pessoa_de_referencia === 'true') {
+        setMainPerson({ value: 'true', label: 'Sim' })
+      } else if (initialValues?.pessoa_de_referencia === 'false') {
+        setMainPerson({ value: 'false', label: 'Não' })
+      } else {
+        setMainPerson({ value: 'ns-nr', label: 'NS/NR' })
+      }
+    }
+  }, [initialValues])
+
   return (
     <StyledForm ref={HouseholdFormRef} onSubmit={handleHouseholdSubmit} >
       <Section>
@@ -191,28 +298,27 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
           <Select name="local_do_domicilio" options={local_do_domicilio} />
         </Label>
         <Label>D2 - A pessoa entrevistada é moradora em situação de rua?</Label>
-        < Select name="morador_de_rua" options={morador_de_rua} />
+        <Select name="morador_de_rua" options={morador_de_rua} />
         <Label>D3 - A moradia está localizada em território de povos e comunidades tradicionais?</Label>
-        < Select
+        <Select
           name="povos_tradicionais"
           options={yesOrNoOptions}
           onChange={(selectedOption: any) => setTraditional(selectedOption)}
         />
         <Label>D4 - Qual comunidade tradicional ou povos?</Label>
-        < Select
+        <Select
           name="qual_povo_tradicional"
           options={qual_povo_tradicional}
           isDisabled={traditional?.value === 'true' ? false : true}
         />
         <Label>D5 - Você é a pessoa de referência da sua casa (chefe da casa)?</Label>
-        < Select
+        <Select
           name="pessoa_de_referencia"
           options={yesOrNoOptions}
           onChange={(selectedOption: any) => setMainPerson(selectedOption)}
         />
 
         <Label>D6 - Qual a idade da pessoa de referência?</Label>
-
 
         {mainPerson?.value === 'false' ?
           (
@@ -223,67 +329,68 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
                 min="16"
                 max="110"
                 name="idade_pessoa_de_referencia"
+                disabled={mainPerson?.value === 'false' ? false : true}
               />
             </>
           ) : null}
 
         <Label>D7 - Qual o sexo da pessoa de referência?</Label>
-        < Select
+        <Select
           name="sexo_pessoa_de_referencia"
           options={genero}
           isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false}
         />
 
         <Label>D8 - Como você define a raça ou cor da pessoa de referência?</Label>
-        < Select name="raca_cor" options={raca_cor} isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false} />
+        <Select name="raca_cor" options={raca_cor} isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false} />
 
         <Label>D9 - A pessoa de referência sabe ler e escrever?</Label>
-        < Select name="ler_escrever" options={yesOrNoOptions} isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false} />
+        <Select name="ler_escrever" options={yesOrNoOptions} isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false} />
 
         <Label>D10 - Até que série (grau) escolar frequentou a pessoa de referência?</Label>
-        < Select name="escolaridade" options={escolaridade} isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false} />
+        <Select name="escolaridade" options={escolaridade} isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false} />
 
         <Label>D11 - Qual a situação de trabalho da pessoa de referência?</Label>
-        < Select
+        <Select
           name="situacao_de_trabalho"
           options={situacao_de_trabalho}
           isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false}
         />
 
         <Label>D12 - Qual a ocupação da pessoa de referência?</Label>
-        < Select
+        <Select
           name="ocupacao_profissional"
           options={ocupacao_profissional}
           isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false}
         />
 
         <Label>D13 - Neste momento qual é o local de trabalho da pessoa de referência?</Label>
-        < Select
+        <Select
           name="local_de_trabalho"
           options={local_de_trabalho}
           isDisabled={mainPerson?.value === 'true' || mainPerson?.value === 'ns-nr' ? true : false}
         />
 
         <Label>D14 - No ano de 2020 (entre Fevereiro e Dezembro de 2020) algum morador da sua casa teve diagnóstico positivo para Coronavírus (ou Covid-19)?</Label>
-        < Select
+        <Select
           name="covid_2020"
           options={yesOrNoOptions}
         />
 
         <Label>D15 - No ano de 2021 algum morador da sua casa teve diagnóstico positivo para Coronavírus (ou Covid-19)?</Label>
-        < Select
+        <Select
           name="covid_2021"
           options={yesOrNoOptions}
         />
 
         <Label>D16 - No ano de 2022 algum morador da sua casa teve diagnóstico positivo para Coronavírus (ou Covid-19)?</Label>
-        < Select
+        <Select
           name="covid_2022"
           options={yesOrNoOptions}
         />
 
         <Label>D17 - Desde o início da pandemia, vocês perderam alguém (morreu alguém) que morava nesta casa?</Label>
-        < Select
+        <Select
           name="covid_perda"
           options={covid_perda}
         />
@@ -319,7 +426,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
           <CheckboxInput
             name="uma_pessoa_domicilio"
             options={[{
-              id: 'one_person_household',
+              id: 'uma_pessoa_domicilio',
               value: 'true',
               label: 'D24 - Eu moro sozinho',
             }]}
@@ -387,7 +494,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="nao_sabe_renda"
             options={[{
-              id: 'income_unknown',
+              id: 'nao_sabe_renda',
               value: 'true',
               label: 'D30 - Não sei informar',
             }]}
@@ -426,13 +533,13 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
           <CheckboxInput
 
             name="perda_de_emprego"
-            options={[{ id: 'Perda de emprego', value: 'true', label: 'Houve perda de emprego/trabalho de algum membro da casa' }]}
+            options={[{ id: 'perda_de_emprego', value: 'true', label: 'Houve perda de emprego/trabalho de algum membro da casa' }]}
           />
 
           <CheckboxInput
 
             name="reducao_de_salario"
-            options={[{ id: 'reducao_de_renda', value: 'true', label: 'Houve redução da renda domiciliar (dos moradores da casa)' }]}
+            options={[{ id: 'reducao_de_salario', value: 'true', label: 'Houve redução da renda domiciliar (dos moradores da casa)' }]}
           />
 
           <CheckboxInput
@@ -444,7 +551,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
           <CheckboxInput
 
             name="divida"
-            options={[{ id: 'dividas', value: 'true', label: 'Houve endividamento de moradores' }]}
+            options={[{ id: 'divida', value: 'true', label: 'Houve endividamento de moradores' }]}
           />
 
           <CheckboxInput
@@ -774,7 +881,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
             name="feijao"
 
             options={[{
-              id: 'Feijão',
+              id: 'feijao',
               value: 'true',
               label: 'Feijão',
             }]}
@@ -785,7 +892,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="arroz"
             options={[{
-              id: 'Arroz',
+              id: 'arroz',
               value: 'true',
               label: 'Arroz',
             }]}
@@ -795,7 +902,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="carnes"
             options={[{
-              id: 'Carnes (de boi, peixe, frango ou porco)',
+              id: 'carnes',
               value: 'true',
               label: 'Carnes (de boi, peixe, frango ou porco)',
             }]}
@@ -805,7 +912,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="verduras_legumes"
             options={[{
-              id: 'Verduras e/ou legumes',
+              id: 'verduras_legumes',
               value: 'true',
               label: 'Verduras e/ou legumes (não considerar batata, mandioca, aipim, macaxeira, cará e inhame)',
             }]}
@@ -815,7 +922,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="frutas_frescas"
             options={[{
-              id: 'Frutas frescas',
+              id: 'frutas_frescas',
               value: 'true',
               label: 'Frutas frescas (não considerar suco de frutas)',
             }]}
@@ -825,7 +932,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="leite"
             options={[{
-              id: 'Leite',
+              id: 'leite',
               value: 'true',
               label: 'Leite e derivados',
             }]}
@@ -835,7 +942,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="hamburguer_embutidos"
             options={[{
-              id: 'Hambúrguer e/ou embutidos',
+              id: 'hamburguer_embutidos',
               value: 'true',
               label: 'Hambúrguer e/ou embutidos (presunto, mortadela, salame, linguiça, salsicha)',
             }]}
@@ -845,7 +952,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="bebidas_adocadas"
             options={[{
-              id: 'Bebidas adoçadas',
+              id: 'bebidas_adocadas',
               value: 'true',
               label: 'Bebidas adoçadas (refrigerante, suco de caixinha, suco em pó, água de coco de caixinha, xaropes de guaraná/groselha, suco de fruta com adição de açúcar)',
             }]}
@@ -855,7 +962,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="macarrao_instantaneo_salgadinhos_de_pacote_biscoitos_salgados"
             options={[{
-              id: 'Macarrão instantâneo, salgadinhos de pacote ou biscoitos salgados',
+              id: 'macarrao_instantaneo_salgadinhos_de_pacote_biscoitos_salgados',
               value: 'true',
               label: 'Macarrão instantâneo, salgadinhos de pacote ou biscoitos salgados',
             }]}
@@ -865,14 +972,14 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
             name="biscoito_recheado_doces_guloseimas"
             options={[{
-              id: 'Biscoito recheado, doces ou guloseimas',
+              id: 'biscoito_recheado_doces_guloseimas',
               value: 'true',
               label: 'Biscoito recheado, doces ou guloseimas (balas, pirulitos, chiclete, caramelo, gelatina)',
             }]}
           />
 
         </CheckBoxContainer>
-        <Button>Submit</Button>
+        {!isEditForm && <Button>Submit</Button>}
       </Section>
 
     </StyledForm >

--- a/src/pages/Interview/Forms/InterviewForm/index.tsx
+++ b/src/pages/Interview/Forms/InterviewForm/index.tsx
@@ -29,9 +29,11 @@ import ICreateOfflineInterviewDTO from '../../dtos/ICreateOfflineInterviewDTO';
 interface InterviewFormProps {
   dispatch: Function;
   offline: boolean;
+  isEditForm?: boolean;
+  initialValues?: any;
 }
 
-const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline }) => {
+const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline, isEditForm = false, initialValues = {} }) => {
 
   const { addToast } = useToast();
 
@@ -139,12 +141,24 @@ const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline }) => {
       } else {
         addToast({
           type: 'error',
+          //@ts-ignore
           title: error?.data?.message,
           description: 'Ocorreu um erro ao adicionar a entrevista, tente novamente',
         });
       }
     }
   }, [addToast, token, history, dispatch, offline]);
+
+  if (isEditForm) {
+    InterviewFormRef.current?.setData({
+      project_name: initialValues?.project?.name,
+      project_number: initialValues?.project?.project_number,
+      interview_type: initialValues?.interview_type,
+      is_complete: initialValues?.is_complete ? 'completa' : 'completa_com_erros',
+      is_complete_with_errors: initialValues?.is_complete_with_errors ? 'completa_com_erros' : 'completa',
+      comments: initialValues?.comments,
+    })
+  }
 
   return (
     <StyledForm ref={InterviewFormRef} onSubmit={handleInterviewSubmit}>
@@ -178,7 +192,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline }) => {
         <Select name="interview_type" options={interviewTypeOptions} />
         <Divider />
         <TextArea name="comments" placeholder="Comentários sobre a entrevista" rows={4} cols={200} />
-        <Button>Submit</Button>
+        {!isEditForm && <Button>Submit</Button>}
       </section>
 
     </StyledForm>

--- a/src/pages/Interview/Forms/PersonForm/index.tsx
+++ b/src/pages/Interview/Forms/PersonForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import {
   OptionTypeBase
 } from 'react-select';
@@ -41,11 +41,15 @@ import ICreateOfflineInterviewDTO from '../../dtos/ICreateOfflineInterviewDTO';
 interface PersonFormProps {
   dispatch: Function;
   offline: boolean;
+  initialValues?: any
+  isEditForm?: boolean
 }
 
-const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline }) => {
+const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline, initialValues = {}, isEditForm = false }) => {
 
   const [vaccine, setVaccine] = useState<OptionTypeBase | undefined | null>({});
+
+  const valores = initialValues
 
   const { user, token } = useAuth();
 
@@ -116,8 +120,30 @@ const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline }) => {
     }
   }, [addToast, user, token, dispatch, offline]);
 
+
+  if (isEditForm) {
+    PersonFormRef.current?.setData({
+      nome: initialValues?.nome,
+      idade: initialValues?.idade,
+      sexo: initialValues?.sexo,
+      raca_cor: initialValues?.raca_cor,
+      ler_escrever: initialValues?.ler_escrever,
+      escolaridade: initialValues?.escolaridade,
+      situacao_de_trabalho: initialValues?.situacao_de_trabalho,
+      ocupacao: initialValues?.ocupacao,
+      local_de_trabalho: initialValues?.local_de_trabalho,
+      diagnostico_covid: initialValues?.diagnostico_covid,
+      vacina: initialValues?.vacina,
+      nao_tomou_vacina: initialValues?.nao_tomou_vacina,
+    })
+  }
+
+
   return (
-    <StyledForm ref={PersonFormRef} onSubmit={handlePersonSubmit} >
+    <StyledForm
+      ref={PersonFormRef}
+      onSubmit={handlePersonSubmit}
+    >
       <section>
         <Label>P1 - Qual o seu nome completo?</Label>
         <Input icon={FiUser} placeholder="Nome Completo" name="nome" />
@@ -125,45 +151,45 @@ const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline }) => {
         <Input name="idade" type="number" min="16" max="110" />
 
         <Label>P3 - Qual o seu sexo?</Label>
-        < Select name="sexo" options={genero} />
+        <Select name="sexo" options={genero} />
       </section>
 
-      < section >
+      <section >
         <Label>P4 - Como você define sua raça ou cor?</Label>
-        < Select name="raca_cor" options={raca_cor} />
+        <Select name="raca_cor" options={raca_cor} />
         <Label>P5 - Você sabe ler e escrever?</Label>
-        < Select name="ler_escrever" options={yesOrNoOptions} />
+        <Select name="ler_escrever" options={yesOrNoOptions} />
       </section>
 
-      < section >
+      <section >
         <Label>P6 - Até que série (grau) você frequentou na escola?</Label>
-        < Select name="escolaridade" options={escolaridade} />
+        <Select name="escolaridade" options={escolaridade} />
         <Label>P7 - Qual a situação de trabalho?</Label>
-        < Select
+        <Select
           name="situacao_de_trabalho"
           options={situacao_de_trabalho}
         />
 
         <Label>P8 - Qual a sua ocupação profissional?</Label>
-        < Select
+        <Select
           name="ocupacao"
           options={ocupacao_profissional}
         />
 
         <Label>P9 - Neste momento qual é o seu local de trabalho?</Label>
-        < Select
+        <Select
           name="local_de_trabalho"
           options={local_de_trabalho}
         />
         <Label>P10 - Você já teve diagnóstico positivo para o novo coronavírus (ou Covid-19)?</Label>
-        < Select name="diagnostico_covid" options={diagnostico_covid} />
+        <Select name="diagnostico_covid" options={diagnostico_covid} />
         <Label>
           P11 - Você já tomou a vacina da Covid-19?
         </Label>
         <Select
           name="vacina"
           options={vacina}
-          onChange={selectedOption => setVaccine(selectedOption)}
+          onChange={(selectedOption: any) => setVaccine(selectedOption)}
         />
 
         <Label>

--- a/src/pages/Interview/Forms/PersonForm/index.tsx
+++ b/src/pages/Interview/Forms/PersonForm/index.tsx
@@ -49,8 +49,6 @@ const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline, initialValue
 
   const [vaccine, setVaccine] = useState<OptionTypeBase | undefined | null>({});
 
-  const valores = initialValues
-
   const { user, token } = useAuth();
 
   const { addToast } = useToast();
@@ -138,7 +136,6 @@ const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline, initialValue
     })
   }
 
-
   return (
     <StyledForm
       ref={PersonFormRef}
@@ -200,7 +197,8 @@ const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline, initialValue
           options={nao_tomou_vacina}
           isDisabled={vaccine?.value === 'Não tomei nenhuma dose da vacina' || vaccine?.value === 'ns-nr' ? false : true}
         />
-        <Button type="submit" > Submit </Button>
+        {!isEditForm && <Button type="submit">Submit</Button>}
+
       </section>
     </StyledForm>
   );

--- a/src/pages/Interview/Forms/PersonForm/index.tsx
+++ b/src/pages/Interview/Forms/PersonForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import {
   OptionTypeBase
 } from 'react-select';

--- a/src/pages/Interview/index.tsx
+++ b/src/pages/Interview/index.tsx
@@ -3,25 +3,22 @@ import {
   Container,
   Header,
   SectionTitle,
-  ResponsiveMenu,
   SubmittedContainer,
   ButtonsContainer,
   OfflineLabel,
   ResetButton
 } from './styles';
-import {
-  FiMenu,
-} from 'react-icons/fi';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import Switch from "react-switch";
 import logo from '../../assets/logo_transparent.png';
-import ScrollSpy from '../../components/ScrollSpy';
 import InterviewForm from './Forms/InterviewForm';
 import PersonForm from './Forms/PersonForm';
 /* import FamilyMemberForm from './Forms/FamilyMemberForm'; */
 import HouseholdForm from './Forms/HouseholdForm';
 import AddressForm from './Forms/AddressForm';
 import ICreateOfflineInterviewDTO from '../Interview/dtos/ICreateOfflineInterviewDTO';
+import api from '../../services/api';
+import { useAuth } from '../../hooks/auth';
 
 interface StateFormat {
   formsSubmitted: {
@@ -91,6 +88,32 @@ function reducer(state: StateFormat, action: FormActionFormat) {
 }
 
 const Interview: React.FC = () => {
+  //@ts-ignore
+  const { id } = useParams();
+  const { token } = useAuth();
+  const [initialValues, setInitialValues] = useState<any>({})
+
+  async function handleInitialData(id: string) {
+    try {
+      const response = await api.get(`/interviews/get-one/${id}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`
+        }
+      })
+      if (response?.data) {
+        setInitialValues(response?.data)
+      }
+    } catch(err) {
+      console.log('error ', err)
+    }
+  }
+
+  useEffect(() => {
+    if (id) {
+      handleInitialData(id)
+    }
+  }, [id])
 
   const [formState, dispatch] = useReducer(reducer, initialState);
 
@@ -163,17 +186,17 @@ const Interview: React.FC = () => {
         </ButtonsContainer>
       </Header>
 
-      <ResponsiveMenu>
+      {/* <ResponsiveMenu>
         <FiMenu size={30} onClick={() => setMenuOpen(!menuOpen)} />
         <div>
           <ScrollSpy open={menuOpen} />
         </div>
-      </ResponsiveMenu>
+      </ResponsiveMenu> */}
 
       <SectionTitle id="person">Dados Pessoais</SectionTitle>
       {formState.formsSubmitted.person.show ? (
 
-        <PersonForm dispatch={dispatch} offline={isOffline} />) : null}
+      <PersonForm dispatch={dispatch} isEditForm offline={isOffline} initialValues={initialValues ? initialValues?.person : {}} />) : null}
       {formState.formsSubmitted.person.id !== null ? <SubmittedContainer>Uma pessoa já foi adicionada</SubmittedContainer> : null}
 
       <SectionTitle id="household">Domicílio</SectionTitle>

--- a/src/pages/Interview/index.tsx
+++ b/src/pages/Interview/index.tsx
@@ -6,14 +6,14 @@ import {
   SubmittedContainer,
   ButtonsContainer,
   OfflineLabel,
-  ResetButton
+  ResetButton,
+  EditInterviewCard
 } from './styles';
 import { Link, useParams } from 'react-router-dom';
 import Switch from "react-switch";
 import logo from '../../assets/logo_transparent.png';
 import InterviewForm from './Forms/InterviewForm';
 import PersonForm from './Forms/PersonForm';
-/* import FamilyMemberForm from './Forms/FamilyMemberForm'; */
 import HouseholdForm from './Forms/HouseholdForm';
 import AddressForm from './Forms/AddressForm';
 import ICreateOfflineInterviewDTO from '../Interview/dtos/ICreateOfflineInterviewDTO';
@@ -117,8 +117,6 @@ const Interview: React.FC = () => {
 
   const [formState, dispatch] = useReducer(reducer, initialState);
 
-  const [menuOpen, setMenuOpen] = useState(false);
-
   const [isOffline, setIsOffline] = useState(false);
 
 
@@ -136,39 +134,40 @@ const Interview: React.FC = () => {
 
   useEffect(() => {
 
-    const person_id = localStorage.getItem('@Safety:person_id');
-    const household_id = localStorage.getItem('@Safety:household_id');
-    const address_id = localStorage.getItem('@Safety:address_id');
+    if (!id) {
+      const person_id = localStorage.getItem('@Safety:person_id');
+      const household_id = localStorage.getItem('@Safety:household_id');
+      const address_id = localStorage.getItem('@Safety:address_id');
 
-    const offline_id = JSON.parse(localStorage.getItem('@Safety:current-offline-interview-id')!);
+      const offline_id = JSON.parse(localStorage.getItem('@Safety:current-offline-interview-id')!);
 
-    const offlineInterviews: { [key: string]: ICreateOfflineInterviewDTO } = JSON.parse(localStorage.getItem('@Safety:offline-interviews') || '{}');
+      const offlineInterviews: { [key: string]: ICreateOfflineInterviewDTO } = JSON.parse(localStorage.getItem('@Safety:offline-interviews') || '{}');
 
-    if (person_id) {
-      dispatch({ type: 'PERSON', payload: { id: person_id, show: false } })
-    } else if (offlineInterviews && offline_id) {
-      if (offlineInterviews[offline_id]?.hasOwnProperty('person')) {
-        dispatch({ type: 'PERSON', payload: { id: offline_id, show: false } })
+      if (person_id) {
+        dispatch({ type: 'PERSON', payload: { id: person_id, show: false } })
+      } else if (offlineInterviews && offline_id) {
+        if (offlineInterviews[offline_id]?.hasOwnProperty('person')) {
+          dispatch({ type: 'PERSON', payload: { id: offline_id, show: false } })
+        }
       }
-    }
 
-    if (household_id) {
-      dispatch({ type: 'HOUSEHOLD', payload: { id: household_id, show: false } })
-    } else if (offlineInterviews && offline_id) {
-      if (offlineInterviews[offline_id]?.hasOwnProperty('household')) {
-        dispatch({ type: 'HOUSEHOLD', payload: { id: offline_id, show: false } })
+      if (household_id) {
+        dispatch({ type: 'HOUSEHOLD', payload: { id: household_id, show: false } })
+      } else if (offlineInterviews && offline_id) {
+        if (offlineInterviews[offline_id]?.hasOwnProperty('household')) {
+          dispatch({ type: 'HOUSEHOLD', payload: { id: offline_id, show: false } })
+        }
       }
-    }
 
-    if (address_id) {
-      dispatch({ type: 'ADDRESS', payload: { id: address_id, show: false } })
-    } else if (offlineInterviews && offline_id) {
-      if (offlineInterviews[offline_id]?.hasOwnProperty('address')) {
-        dispatch({ type: 'ADDRESS', payload: { id: offline_id, show: false } })
+      if (address_id) {
+        dispatch({ type: 'ADDRESS', payload: { id: address_id, show: false } })
+      } else if (offlineInterviews && offline_id) {
+        if (offlineInterviews[offline_id]?.hasOwnProperty('address')) {
+          dispatch({ type: 'ADDRESS', payload: { id: offline_id, show: false } })
+        }
       }
     }
   }, [dispatch])
-
 
   return (
     <Container offline={isOffline}>
@@ -180,30 +179,47 @@ const Interview: React.FC = () => {
           PenSSAN <span>|</span> Entrevista
         </div>
         <ButtonsContainer>
-          <OfflineLabel offline={isOffline}>{isOffline ? 'Offline' : 'Online'}</OfflineLabel>
-          <Switch onColor="#c2024b" offColor="#dedede" onChange={() => setIsOffline(!isOffline)!} checked={isOffline} />
-          <ResetButton onClick={resetForms}>Reiniciar</ResetButton>
-        </ButtonsContainer>
+          {!initialValues?.project_name && (
+              <>
+              <OfflineLabel offline={isOffline}>{isOffline ? 'Offline' : 'Online'}</OfflineLabel>
+              <Switch onColor="#c2024b" offColor="#dedede" onChange={() => setIsOffline(!isOffline)!} checked={isOffline} />
+              <ResetButton onClick={resetForms}>Reiniciar</ResetButton>
+              </>
+            )}
+          </ButtonsContainer>
       </Header>
 
-      {/* <ResponsiveMenu>
-        <FiMenu size={30} onClick={() => setMenuOpen(!menuOpen)} />
-        <div>
-          <ScrollSpy open={menuOpen} />
-        </div>
-      </ResponsiveMenu> */}
+      {initialValues?.project_name && (
+        <EditInterviewCard>
+          <p>{initialValues?.interviewer?.organization_name} | {initialValues?.project_name} | {initialValues?.interviewer?.name}</p>
+          <p>{new Date(initialValues?.created_at)?.toLocaleDateString()}</p>
+        </EditInterviewCard>
+      )}
 
       <SectionTitle id="person">Dados Pessoais</SectionTitle>
-      {formState.formsSubmitted.person.show ? (
-
-      <PersonForm dispatch={dispatch} isEditForm offline={isOffline} initialValues={initialValues ? initialValues?.person : {}} />) : null}
-      {formState.formsSubmitted.person.id !== null ? <SubmittedContainer>Uma pessoa já foi adicionada</SubmittedContainer> : null}
-
+      {formState.formsSubmitted.person.show && (
+        <PersonForm
+          dispatch={dispatch}
+          isEditForm={id ? true : false}
+          offline={isOffline}
+          initialValues={initialValues ? initialValues?.person : {}}
+        />
+      )}
+      {formState.formsSubmitted.person.id !== null && (
+        <SubmittedContainer>Uma pessoa já foi adicionada</SubmittedContainer>
+      )}
       <SectionTitle id="household">Domicílio</SectionTitle>
-      {formState.formsSubmitted.household.show ? (
-
-        <HouseholdForm dispatch={dispatch} offline={isOffline} />) : null}
-      {formState.formsSubmitted.household.id !== null ? <SubmittedContainer>Uma residência já foi criada</SubmittedContainer> : null}
+      {formState.formsSubmitted.household.show && (
+        <HouseholdForm
+          dispatch={dispatch}
+          isEditForm={id ? true : false}
+          initialValues={initialValues ? initialValues?.household : {}}
+          offline={isOffline}
+        />
+      )}
+      {formState.formsSubmitted.household.id !== null && (
+        <SubmittedContainer>Uma residência já foi criada</SubmittedContainer>
+      )}
 
       {/*       <SectionTitle id="family">
         Membros da Família
@@ -211,15 +227,26 @@ const Interview: React.FC = () => {
 
       <FamilyMemberForm /> */}
       <SectionTitle id="address">Endereço</SectionTitle>
-      {formState.formsSubmitted.address.show ? (
-
-        <AddressForm dispatch={dispatch} offline={isOffline} />) : null}
-      {formState.formsSubmitted.address.id !== null ? <SubmittedContainer>Um endereço já foi criado</SubmittedContainer> : null}
-
+      {formState.formsSubmitted.address.show && (
+        <AddressForm
+          dispatch={dispatch}
+          isEditForm={id ? true : false}
+          initialValues={initialValues ? initialValues?.address : {}}
+          offline={isOffline}
+        />
+      )}
+      {formState.formsSubmitted.address.id !== null && (
+        <SubmittedContainer>Um endereço já foi criado</SubmittedContainer>
+      )}
       <SectionTitle id="interview">Entrevista</SectionTitle>
-      {formState.formsSubmitted.interview.show ? (
-
-        <InterviewForm dispatch={dispatch} offline={isOffline} />) : null}
+      {formState.formsSubmitted.interview.show && (
+        <InterviewForm
+          dispatch={dispatch}
+          isEditForm={id ? true : false}
+          initialValues={initialValues ? initialValues : {}}
+          offline={isOffline}
+        />
+      )}
 
     </Container>
   );

--- a/src/pages/Interview/index.tsx
+++ b/src/pages/Interview/index.tsx
@@ -93,23 +93,22 @@ const Interview: React.FC = () => {
   const { token } = useAuth();
   const [initialValues, setInitialValues] = useState<any>({})
 
-  async function handleInitialData(id: string) {
-    try {
-      const response = await api.get(`/interviews/get-one/${id}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`
-        }
-      })
-      if (response?.data) {
-        setInitialValues(response?.data)
-      }
-    } catch(err) {
-      console.log('error ', err)
-    }
-  }
-
   useEffect(() => {
+    async function handleInitialData(id: string) {
+      try {
+        const response = await api.get(`/interviews/get-one/${id}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`
+          }
+        })
+        if (response?.data) {
+          setInitialValues(response?.data)
+        }
+      } catch(err) {
+        console.log('error ', err)
+      }
+    }
     if (id) {
       handleInitialData(id)
     }
@@ -167,7 +166,7 @@ const Interview: React.FC = () => {
         }
       }
     }
-  }, [dispatch])
+  }, [dispatch, id])
 
   return (
     <Container offline={isOffline}>

--- a/src/pages/Interview/questions/SelectorOptions/options.ts
+++ b/src/pages/Interview/questions/SelectorOptions/options.ts
@@ -365,7 +365,6 @@ export const auxilio_vezes = [
   { value: 'uma vez', label: 'Uma vez' },
   { value: 'duas vezes', label: 'Duas vezes' },
   { value: 'três vezes', label: 'Três vezes' },
-  { value: 'três vezes', label: 'Três vezes' },
   { value: 'ns-nr', label: 'NS/NR' },
 ];
 

--- a/src/pages/Interview/styles.ts
+++ b/src/pages/Interview/styles.ts
@@ -19,6 +19,13 @@ export const SubmittedContainer = styled.div`
   margin-left: 20px;
 `;
 
+export const EditInterviewCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  padding: 20px;
+`;
+
 export const Header = styled.h1`
   padding: 10px 0;
   color: #59748c;

--- a/src/routes/Route.tsx
+++ b/src/routes/Route.tsx
@@ -9,18 +9,21 @@ import AdminTemplate from '../templates/AdminTemplate';
 
 interface RouteProps extends ReactDomRouteProps {
   isPrivate?: boolean;
+  path: string;
   component: React.ComponentType;
 }
 
 const Route: React.FC<RouteProps> = ({
   isPrivate = false,
   component: Component,
+  path,
   ...rest
 }) => {
   const { user } = useAuth();
   return (
     <ReactDomRoute
       {...rest}
+      path={path}
       render={({ location }) => {
         return isPrivate === !!user ? isPrivate ? (
           <AdminTemplate>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,7 +23,8 @@ const Routes: React.FC = () => {
       <Route path="/dashboard" isPrivate component={Dashboard} />
       <Route path="/offline" isPrivate component={OfflineInterviews} />
       <Route path="/accept" isPrivate component={Accept} />
-      <Route path="/interview" isPrivate component={Interview} />
+      <Route exact path="/interview" isPrivate component={Interview} />
+      <Route path="/interview/:id" isPrivate component={Interview} />
       <Route path="/project" isPrivate component={Project} />
       {/* <Route path="/household" isPrivate component={Household} /> */}
       <Route path="/interviewers" isPrivate component={Interviewers} />

--- a/src/services/offlineInterviewsService.ts
+++ b/src/services/offlineInterviewsService.ts
@@ -18,7 +18,7 @@ async function SubmitOfflineInterviews(): Promise<void> {
     localStorage.setItem(`@Safety:offlineBackup - ${format(parseJSON(Date.now()), 'dd/MM/yyyy HH:mm:ss')}`, JSON.stringify(interviews));
 
     for (let interview in interviews) {
-      
+
       if (Object.keys(interviews[interview]).length === 4) {
         try {
 
@@ -83,7 +83,6 @@ async function SubmitOfflineInterviews(): Promise<void> {
           }
         }
       } else {
-        console.log('Essa entrevista não estava completa');
         localStorage.setItem(`@Safety:InterviewNotComplete:${uuid()}`, JSON.stringify(interviews[interview]));
       }
 


### PR DESCRIPTION
## Descrição

### Implementa tela para visualizar todos os dados de uma entrevista

Rota para acesso: `http://localhost:3000/interview/$interview_id`

onde:
$interview_id: id da entrevista


Ao clicar nos cards da listagem de entrevistas da dashboard, será automaticamente encaminhado para a tela com os dados detalhados da entrevista:


_obs_:
- Os dados que alimentam a página estão vindo da API.
- Não é possível editar a entrevista _(podemos implementar se acharem pertinente)_




Tela de cads com atalho para detalhes:
![image](https://user-images.githubusercontent.com/58530162/178398800-212fc73c-1878-4f7d-a5d8-bbdfeb813cb2.png)

Telas da nova página:

![image](https://user-images.githubusercontent.com/58530162/178398613-5aac6455-e263-4a60-bb34-c9889801918f.png)

![image](https://user-images.githubusercontent.com/58530162/178398668-89713b38-ff18-40b4-9c7f-43ae1708aab9.png)

