### PR TITLE
:lock: Sets submit button as disabled when waiting for api request

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -4,9 +4,9 @@ import { Container } from './styles';
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   loading?: boolean;
 };
-const Button: React.FC<ButtonProps> = ({ children, loading, ...rest }) => {
+const Button: React.FC<ButtonProps> = ({ children, loading = false, ...rest }) => {
   return (
-    <Container {...rest}>{loading ? 'Carregando ...' : children}</Container>
+    <Container {...rest} disabled={loading}>{loading ? 'Carregando ...' : children}</Container>
   );
 };
 

--- a/src/pages/Interview/Forms/AddressForm/index.tsx
+++ b/src/pages/Interview/Forms/AddressForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useState } from 'react';
 import * as Yup from 'yup';
 import Select from '../../../../components/Select';
 import { FormHandles } from '@unform/core';
@@ -41,9 +41,12 @@ const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline }) => {
 
   const AddressFormRef = useRef<FormHandles>(null);
 
+  const [loading, setLoading] = useState<boolean>(false)
+
 
   const handleAddressSubmit = useCallback(async (data: ICreateAddressDTO) => {
     try {
+      setLoading(true)
       AddressFormRef.current?.setErrors({});
       const validatedData = await AddressValidation.validate(data, {
         abortEarly: false,
@@ -113,8 +116,10 @@ const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline }) => {
           description: 'Ocorreu um erro ao adicionar o endereço, tente novamente',
         });
       }
+    } finally {
+      setLoading(false)
     }
-  }, [addToast, token, dispatch, offline]);
+  }, [addToast, token, dispatch, offline, setLoading]);
 
   return (
     <StyledForm ref={AddressFormRef} onSubmit={handleAddressSubmit}>
@@ -144,7 +149,7 @@ const AddressForm: React.FC<AddressFormProps> = ({ dispatch, offline }) => {
           placeholder="Número de telefone"
           name="telephone_number"
         />
-        <Button>Submit</Button>
+        <Button loading={loading}>Submit</Button>
       </section>
     </StyledForm>
 

--- a/src/pages/Interview/Forms/HouseholdForm/index.tsx
+++ b/src/pages/Interview/Forms/HouseholdForm/index.tsx
@@ -96,6 +96,8 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
   const HouseholdFormRef = useRef<FormHandles>(null);
 
+  const [loading, setLoading] = useState<boolean>(false)
+
   const handleHouseholdSubmit = useCallback(
     async (data: ICreateHouseholdDTO) => {
 
@@ -104,6 +106,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
 
 
       try {
+        setLoading(true)
         HouseholdFormRef.current?.setErrors({});
 
         const validatedData = await HouseholdValidation.validate(parsedData, {
@@ -178,9 +181,11 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
         } else {
           console.log(error);
         }
+      } finally {
+        setLoading(false)
       }
     },
-    [addToast, token, dispatch, offline],
+    [addToast, token, dispatch, offline, setLoading],
   );
 
   return (
@@ -367,7 +372,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
                 type="number"
               />
               <Label>
-                D29 - Desde o início da pandemia do Coronavírus (ou Convid-19) em 2020 até o dia de hoje, vocês acolheram alguém na sua família como morador permanente? 
+                D29 - Desde o início da pandemia do Coronavírus (ou Convid-19) em 2020 até o dia de hoje, vocês acolheram alguém na sua família como morador permanente?
               </Label>
               <Select
                 name="pessoas_convidadas"
@@ -872,7 +877,7 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ dispatch, offline }) => {
           />
 
         </CheckBoxContainer>
-        <Button>Submit</Button>
+        <Button loading={loading}>Submit</Button>
       </Section>
 
     </StyledForm >

--- a/src/pages/Interview/Forms/InterviewForm/index.tsx
+++ b/src/pages/Interview/Forms/InterviewForm/index.tsx
@@ -43,6 +43,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline }) => {
 
   const InterviewFormRef = useRef<FormHandles>(null);
 
+  const [loading, setLoading] = useState<boolean>(false)
 
   const handleInterviewSubmit = useCallback(async (data: ICreateInterviewDTO) => {
 
@@ -52,7 +53,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline }) => {
     }
 
     try {
-
+      setLoading(true)
       InterviewFormRef.current?.setErrors({});
 
       const validatedData = await InterviewValidation.validate(parsedData, {
@@ -63,11 +64,11 @@ const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline }) => {
 
         const interviewer_id = await JSON.parse(localStorage.getItem('@Safety:user') || '')?.id;
 
-        const household_id = await localStorage.getItem('@Safety:household_id');
+        const household_id = localStorage.getItem('@Safety:household_id');
 
-        const person_id = await localStorage.getItem('@Safety:person_id');
+        const person_id = localStorage.getItem('@Safety:person_id');
 
-        const address_id = await localStorage.getItem('@Safety:address_id');
+        const address_id = localStorage.getItem('@Safety:address_id');
 
         const interview = {
           interviewer_id,
@@ -143,8 +144,10 @@ const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline }) => {
           description: 'Ocorreu um erro ao adicionar a entrevista, tente novamente',
         });
       }
+    } finally {
+      setLoading(false)
     }
-  }, [addToast, token, history, dispatch, offline]);
+  }, [addToast, token, history, dispatch, offline, setLoading]);
 
   return (
     <StyledForm ref={InterviewFormRef} onSubmit={handleInterviewSubmit}>
@@ -178,7 +181,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({ dispatch, offline }) => {
         <Select name="interview_type" options={interviewTypeOptions} />
         <Divider />
         <TextArea name="comments" placeholder="Comentários sobre a entrevista" rows={4} cols={200} />
-        <Button>Submit</Button>
+        <Button loading={loading}>Submit</Button>
       </section>
 
     </StyledForm>

--- a/src/pages/Interview/Forms/PersonForm/index.tsx
+++ b/src/pages/Interview/Forms/PersonForm/index.tsx
@@ -53,8 +53,12 @@ const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline }) => {
 
   const PersonFormRef = useRef<FormHandles>(null);
 
+  const [loading, setLoading] = useState<boolean>(false)
+
   const handlePersonSubmit = useCallback(async (data: ICreatePersonDTO) => {
+
     try {
+      setLoading(true)
       PersonFormRef.current?.setErrors({});
       const validatedData = await PersonValidation.validate(data, {
         abortEarly: false,
@@ -113,8 +117,10 @@ const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline }) => {
           description: 'Todos os campos devem estar selecionados',
         });
       }
+    } finally {
+      setLoading(false)
     }
-  }, [addToast, user, token, dispatch, offline]);
+  }, [addToast, user, token, dispatch, offline, setLoading]);
 
   return (
     <StyledForm ref={PersonFormRef} onSubmit={handlePersonSubmit} >
@@ -174,7 +180,7 @@ const PersonForm: React.FC<PersonFormProps> = ({ dispatch, offline }) => {
           options={nao_tomou_vacina}
           isDisabled={vaccine?.value === 'Não tomei nenhuma dose da vacina' || vaccine?.value === 'ns-nr' ? false : true}
         />
-        <Button type="submit" > Submit </Button>
+        <Button loading={loading} type="submit">Submit</Button>
       </section>
     </StyledForm>
   );

--- a/src/pages/Interview/index.tsx
+++ b/src/pages/Interview/index.tsx
@@ -171,16 +171,16 @@ const Interview: React.FC = () => {
       </ResponsiveMenu>
 
       <SectionTitle id="person">Dados Pessoais</SectionTitle>
-      {formState.formsSubmitted.person.show ? (
+      {formState.formsSubmitted.person.show && (
 
-        <PersonForm dispatch={dispatch} offline={isOffline} />) : null}
-      {formState.formsSubmitted.person.id !== null ? <SubmittedContainer>Uma pessoa já foi adicionada</SubmittedContainer> : null}
+      <PersonForm dispatch={dispatch} offline={isOffline} />)}
+      {formState.formsSubmitted.person.id !== null && <SubmittedContainer>Uma pessoa já foi adicionada</SubmittedContainer>}
 
       <SectionTitle id="household">Domicílio</SectionTitle>
-      {formState.formsSubmitted.household.show ? (
+      {formState.formsSubmitted.household.show && (
 
-        <HouseholdForm dispatch={dispatch} offline={isOffline} />) : null}
-      {formState.formsSubmitted.household.id !== null ? <SubmittedContainer>Uma residência já foi criada</SubmittedContainer> : null}
+      <HouseholdForm dispatch={dispatch} offline={isOffline} />)}
+      {formState.formsSubmitted.household.id !== null && <SubmittedContainer>Uma residência já foi criada</SubmittedContainer>}
 
       {/*       <SectionTitle id="family">
         Membros da Família
@@ -188,15 +188,15 @@ const Interview: React.FC = () => {
 
       <FamilyMemberForm /> */}
       <SectionTitle id="address">Endereço</SectionTitle>
-      {formState.formsSubmitted.address.show ? (
+      {formState.formsSubmitted.address.show && (
 
-        <AddressForm dispatch={dispatch} offline={isOffline} />) : null}
-      {formState.formsSubmitted.address.id !== null ? <SubmittedContainer>Um endereço já foi criado</SubmittedContainer> : null}
+        <AddressForm dispatch={dispatch} offline={isOffline} />)}
+      {formState.formsSubmitted.address.id !== null && <SubmittedContainer>Um endereço já foi criado</SubmittedContainer>}
 
       <SectionTitle id="interview">Entrevista</SectionTitle>
-      {formState.formsSubmitted.interview.show ? (
+      {formState.formsSubmitted.interview.show && (
 
-        <InterviewForm dispatch={dispatch} offline={isOffline} />) : null}
+      <InterviewForm dispatch={dispatch} offline={isOffline} />)}
 
     </Container>
   );


### PR DESCRIPTION
## Descrição
Corrige envio duplicado de dados (ao clicar 02 vezes no botão _Submit_)


### Implementa
Desabilita o botão _Submit_ **enquanto aguarda** o envio de dados para a _API_, nos formulários de:
- PersonForm
- AddressForm
- HouseholdForm
- InterviewForm